### PR TITLE
Add REDACTIVE_CONNECTION_MODE env var

### DIFF
--- a/sdks/python/src/redactive/_connection_mode.py
+++ b/sdks/python/src/redactive/_connection_mode.py
@@ -1,0 +1,43 @@
+import os
+from enum import StrEnum
+
+
+class ConnectionMode(StrEnum):
+    Internet = "internet"
+    AWSPrivateLink = "awsprivatelink"
+    AzurePrivateLink = "azureprivatelink"
+    GCPPrivateServiceConnect = "gcpprivateserviceconnect"
+
+
+def _get_environment_connection_mode() -> ConnectionMode:
+    connection_mode_str = os.environ.get("REDACTIVE_CONNECTION_MODE", ConnectionMode.Internet.value).lower()
+    try:
+        return ConnectionMode(connection_mode_str)
+    except ValueError as e:
+        msg = f"Invalid env var REDACTIVE_CONNECTION_MODE set to '{connection_mode_str}'"
+        raise ValueError(msg) from e
+
+
+_endpoints = {
+    ConnectionMode.Internet: {"http": "https://api.redactive.ai", "grpc": ("grpc.redactive.ai", 443)},
+    ConnectionMode.AWSPrivateLink: {
+        "http": "https://awsprivatelink.redactive.app",
+        "grpc": ("awsprivatelink.redactive.app", 50443),
+    },
+}
+
+
+def get_default_http_endpoint() -> str:
+    cm = _get_environment_connection_mode()
+    if cm not in _endpoints:
+        msg = f"{cm} is coming soon and not yet supported as a connection mode"
+        raise ValueError(msg)
+    return _endpoints[cm]["http"]
+
+
+def get_default_grpc_host_and_port() -> tuple[str, int]:
+    cm = _get_environment_connection_mode()
+    if cm not in _endpoints:
+        msg = f"{cm} is coming soon and not yet supported as a connection mode"
+        raise ValueError(msg)
+    return _endpoints[cm]["grpc"]

--- a/sdks/python/src/redactive/auth_client.py
+++ b/sdks/python/src/redactive/auth_client.py
@@ -3,6 +3,8 @@ import http
 import httpx
 from pydantic import BaseModel
 
+from redactive._connection_mode import get_default_http_endpoint as _get_default_http_endpoint
+
 
 class ExchangeTokenResponse(BaseModel):
     idToken: str  # noqa: N815
@@ -15,15 +17,17 @@ class BeginConnectionResponse(BaseModel):
 
 
 class AuthClient:
-    def __init__(self, api_key: str, base_url: str = "https://api.redactive.ai"):
+    def __init__(self, api_key: str, base_url: str | None = None):
         """
         Initialize the connection settings for the service.
 
         :param api_key: The API key used for authentication.
         :type api_key: str
-        :param base_url: The base URL for the HTTP client, defaults to "https://api.redactive.ai"
+        :param base_url: The base URL to use for Redactive.
         :type base_url: str, optional
         """
+        if base_url is None:
+            base_url = _get_default_http_endpoint()
 
         self._client = httpx.AsyncClient(base_url=f"{base_url}", auth=BearerAuth(api_key))
 

--- a/sdks/python/src/redactive/search_client.py
+++ b/sdks/python/src/redactive/search_client.py
@@ -1,19 +1,28 @@
 from grpclib.client import Channel
 
+from redactive._connection_mode import get_default_grpc_host_and_port as _get_default_grpc_host_and_port
 from redactive.grpc.v1 import Filters, Query, QueryRequest, RelevantChunk, SearchStub
 
 
 class SearchClient:
-    def __init__(self, host: str = "grpc.redactive.ai", port: int = 443) -> None:
+    def __init__(self, host: str | None = None, port: int | None = None) -> None:
         """
         Initialize the connection settings for the service.
 
-        :param host: The hostname or IP address of the service, defaults to "grpc.redactive.ai"
+        :param host: The hostname or IP address of the service
         :type host: str, optional
-        :param port: The port number to connect to, defaults to 443
+        :param port: The port number to connect to
         :type port: int, optional
         """
-        self.access_token = None
+        if host is not None and port is None:
+            msg = "Port must also be specified if host is specified"
+            raise ValueError(msg)
+        if port is not None and host is None:
+            msg = "Host must also be specified if port is specified"
+            raise ValueError(msg)
+        if host is None and port is None:
+            host, port = _get_default_grpc_host_and_port()
+
         self.host = host
         self.port = port
 


### PR DESCRIPTION
Adds a `REDACTIVE_CONNECTION_MODE` environment variable that can be set to `awsprivatelink` for users connecting over AWS Private Link. Defaults to connecting to Redactive over the internet if unset.