### PR TITLE
feat(python): Adds support for endpoint and code_param_alias to begin_connection

### DIFF
--- a/sdks/python/src/redactive/auth_client.py
+++ b/sdks/python/src/redactive/auth_client.py
@@ -55,10 +55,10 @@ class AuthClient:
             if code_param_alias:
                 params["code_param_alias"] = code_param_alias
             response = await self._client.post(url=f"/api/auth/connect/{provider}/url", params=params)
-            if response.status_code == 200:
-                return response.json()
-            else:
-                raise httpx.RequestError(response.text)
+            if response.status_code != http.HTTPStatus.OK:
+               raise httpx.RequestError(response.text)
+
+            return BeginConnectionResponse(**response.json())
 
     async def exchange_tokens(self, code: str | None = None, refresh_token: str | None = None) -> ExchangeTokenResponse:
         """

--- a/sdks/python/src/redactive/auth_client.py
+++ b/sdks/python/src/redactive/auth_client.py
@@ -32,8 +32,8 @@ class AuthClient:
         self._client = httpx.AsyncClient(base_url=f"{base_url}", auth=BearerAuth(api_key))
 
     async def begin_connection(
-            self, provider: str, redirect_uri: str, endpoint: str | None = None, code_param_alias: str | None = None
-        ) -> BeginConnectionResponse:
+        self, provider: str, redirect_uri: str, endpoint: str | None = None, code_param_alias: str | None = None
+    ) -> BeginConnectionResponse:
         """
         Initiates a connection process with a specified provider.
 

--- a/sdks/python/src/redactive/auth_client.py
+++ b/sdks/python/src/redactive/auth_client.py
@@ -33,7 +33,7 @@ class AuthClient:
 
     async def begin_connection(
             self, provider: str, redirect_uri: str, endpoint: str | None = None, code_param_alias: str | None = None
-        ) -> str:
+        ) -> BeginConnectionResponse:
             """
             Initiates a connection process with a specified provider.
 

--- a/sdks/python/src/redactive/auth_client.py
+++ b/sdks/python/src/redactive/auth_client.py
@@ -34,31 +34,31 @@ class AuthClient:
     async def begin_connection(
             self, provider: str, redirect_uri: str, endpoint: str | None = None, code_param_alias: str | None = None
         ) -> BeginConnectionResponse:
-            """
-            Initiates a connection process with a specified provider.
+        """
+        Initiates a connection process with a specified provider.
 
-            :param provider: The name of the provider to connect with.
-            :type provider: str
-            :param redirect_uri: The URI to redirect to after initiating the connection. Defaults to an empty string.
-            :type redirect_uri: str
-            :param endpoint: The endpoint to use to access specific provider APIs. Only required if connecting to Zendesk. Defaults to None.
-            :type endpoint: str, optional
-            :param code_param_alias: The alias for the code parameter. This is the name of the query parameter that will need to be passed to the `/auth/token` endpoint as `code`. Defaults to None and will be `code` on the return.
-            :type code_param_alias: str, optional
-            :raises httpx.RequestError: If an error occurs while making the HTTP request.
-            :return: The URL to redirect the user to for beginning the connection.
-            :rtype: BeginConnectionResponse
-            """
-            params = {"redirect_uri": redirect_uri}
-            if endpoint:
-                params["endpoint"] = endpoint
-            if code_param_alias:
-                params["code_param_alias"] = code_param_alias
-            response = await self._client.post(url=f"/api/auth/connect/{provider}/url", params=params)
-            if response.status_code != http.HTTPStatus.OK:
-               raise httpx.RequestError(response.text)
+        :param provider: The name of the provider to connect with.
+        :type provider: str
+        :param redirect_uri: The URI to redirect to after initiating the connection. Defaults to an empty string.
+        :type redirect_uri: str
+        :param endpoint: The endpoint to use to access specific provider APIs. Only required if connecting to Zendesk. Defaults to None.
+        :type endpoint: str, optional
+        :param code_param_alias: The alias for the code parameter. This is the name of the query parameter that will need to be passed to the `/auth/token` endpoint as `code`. Defaults to None and will be `code` on the return.
+        :type code_param_alias: str, optional
+        :raises httpx.RequestError: If an error occurs while making the HTTP request.
+        :return: The URL to redirect the user to for beginning the connection.
+        :rtype: BeginConnectionResponse
+        """
+        params = {"redirect_uri": redirect_uri}
+        if endpoint:
+            params["endpoint"] = endpoint
+        if code_param_alias:
+            params["code_param_alias"] = code_param_alias
+        response = await self._client.post(url=f"/api/auth/connect/{provider}/url", params=params)
+        if response.status_code != http.HTTPStatus.OK:
+            raise httpx.RequestError(response.text)
 
-            return BeginConnectionResponse(**response.json())
+        return BeginConnectionResponse(**response.json())
 
     async def exchange_tokens(self, code: str | None = None, refresh_token: str | None = None) -> ExchangeTokenResponse:
         """

--- a/sdks/python/src/redactive/auth_client.py
+++ b/sdks/python/src/redactive/auth_client.py
@@ -37,18 +37,17 @@ class AuthClient:
             """
             Initiates a connection process with a specified provider.
 
-            Parameters:
-                provider (str): The name of the provider to connect with.
-                redirect_uri (str): The URI to redirect to after initiating the connection. Defaults to an empty string.
-                endpoint (str, optional): The endpoint to use to access specific provider APIs. Only required if connecting to Zendesk. Defaults to None.
-                code_param_alias (str, optional): The alias for the code parameter. This is the name of the query parameter that will need to be passed to the `/auth/token` endpoint as `code`. Defaults to None and will be `code` on the return.
-
-            Returns:
-                str: The URL to redirect the user to for beginning the connection.
-
-            Raises:
-                httpx.HTTPStatusError: If the HTTP request returns an unsuccessful status code.
-                httpx.RequestError: If an error occurs while making the HTTP request.
+            :param provider: The name of the provider to connect with.
+            :type provider: str
+            :param redirect_uri: The URI to redirect to after initiating the connection. Defaults to an empty string.
+            :type redirect_uri: str
+            :param endpoint: The endpoint to use to access specific provider APIs. Only required if connecting to Zendesk. Defaults to None.
+            :type endpoint: str, optional
+            :param code_param_alias: The alias for the code parameter. This is the name of the query parameter that will need to be passed to the `/auth/token` endpoint as `code`. Defaults to None and will be `code` on the return.
+            :type code_param_alias: str, optional
+            :raises httpx.RequestError: If an error occurs while making the HTTP request.
+            :return: The URL to redirect the user to for beginning the connection.
+            :rtype: BeginConnectionResponse
             """
             params = {"redirect_uri": redirect_uri}
             if endpoint:


### PR DESCRIPTION
Adds support for two new parameters in the `begin_connection` command