### PR TITLE
ci: fixed Github Node SDK publishing workflow

### DIFF
--- a/.github/workflows/package-node-sdk.yaml
+++ b/.github/workflows/package-node-sdk.yaml
@@ -32,6 +32,11 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: redactive-node-sdk
+          path: ./sdks/node/dist/
 
   publish:
     name: 🚚 Publish Node SDK to NPM
@@ -42,6 +47,11 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: redactive-node-sdk
+          path: ./sdks/node/dist/
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -53,10 +63,6 @@ jobs:
         with:
           version: 9
           run_install: false
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build
-        run: pnpm build
       - name: Publish Node SDK to NPM
         shell: bash
         run: pnpm version ${GITHUB_REF#refs/*/} && pnpm publish --access public --no-git-checks

--- a/.github/workflows/package-node-sdk.yaml
+++ b/.github/workflows/package-node-sdk.yaml
@@ -40,12 +40,15 @@ jobs:
 
   publish:
     name: 🚚 Publish Node SDK to NPM
-    if: startsWith(github.ref, 'refs/tags/') # only publish to NPM on tag pushes
+    # if: startsWith(github.ref, 'refs/tags/') # only publish to NPM on tag pushes
     needs: build
     runs-on: ubuntu-latest
     environment: release
     permissions:
       id-token: write
+    defaults:
+      run:
+        working-directory: ./sdks/node
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7

--- a/.github/workflows/package-node-sdk.yaml
+++ b/.github/workflows/package-node-sdk.yaml
@@ -40,7 +40,7 @@ jobs:
 
   publish:
     name: 🚚 Publish Node SDK to NPM
-    # if: startsWith(github.ref, 'refs/tags/') # only publish to NPM on tag pushes
+    if: startsWith(github.ref, 'refs/tags/') # only publish to NPM on tag pushes
     needs: build
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/package-node-sdk.yaml
+++ b/.github/workflows/package-node-sdk.yaml
@@ -54,7 +54,18 @@ jobs:
         with:
           name: redactive-node-sdk
           path: dist/
-      - name: Publish 🚀
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Set up Node
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+      - name: Install pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 9
+          run_install: false
+      - name: Publish Node SDK to NPM
         shell: bash
         run: pnpm version ${GITHUB_REF#refs/*/} && pnpm publish --access public --no-git-checks
         env:

--- a/.github/workflows/package-node-sdk.yaml
+++ b/.github/workflows/package-node-sdk.yaml
@@ -6,9 +6,37 @@ on:
       - "sdks/node/**"
 
 jobs:
+  build:
+    name: 📦 Build distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    defaults:
+      run:
+        working-directory: ./sdks/node
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Set up Node
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+      - name: Install pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 9
+          run_install: false
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
+
   publish:
     name: 🚚 Publish Node SDK to NPM
     if: startsWith(github.ref, 'refs/tags/') # only publish to NPM on tag pushes
+    needs: build
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/package-node-sdk.yaml
+++ b/.github/workflows/package-node-sdk.yaml
@@ -6,16 +6,13 @@ on:
       - "sdks/node/**"
 
 jobs:
-  build:
-    name: 📦 Build distribution
+  publish:
+    name: 🚚 Publish Node SDK to NPM
+    if: startsWith(github.ref, 'refs/tags/') # only publish to NPM on tag pushes
     runs-on: ubuntu-latest
+    environment: release
     permissions:
-      contents: write
       id-token: write
-    defaults:
-      run:
-        working-directory: ./sdks/node
-
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up Node
@@ -30,41 +27,8 @@ jobs:
           run_install: false
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        working-directory: ./sdks/node
       - name: Build
         run: pnpm build
-        working-directory: ./sdks/node
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          name: redactive-node-sdk
-          path: ./sdks/node/dist/
-
-  publish:
-    name: 🚚 Publish Node SDK to NPM
-    if: startsWith(github.ref, 'refs/tags/') # only publish to NPM on tag pushes
-    needs: build
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        with:
-          name: redactive-node-sdk
-          path: dist/
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Set up Node
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
-        with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-      - name: Install pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-        with:
-          version: 9
-          run_install: false
       - name: Publish Node SDK to NPM
         shell: bash
         run: pnpm version ${GITHUB_REF#refs/*/} && pnpm publish --access public --no-git-checks

--- a/.github/workflows/package-python-sdk.yaml
+++ b/.github/workflows/package-python-sdk.yaml
@@ -39,8 +39,7 @@ jobs:
           path: ./sdks/python/dist/
 
   publish:
-    name: >-
-      🚚 Publish Python SDK to PyPI
+    name: 🚚 Publish Python SDK to PyPI
     if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Install `deps` for `publish` job 
- Fixed Github Action job `working-directory`