### PR TITLE
Add & update docstrings, type hints, param defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redactive
 
-The Redactive Application, Docs &amp; Samples
+The Redactive Application, Docs & Samples
 
 ## Directory Structure
 

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -77,7 +77,31 @@ const documentName = "AI Research Paper";
 await client.queryChunksByDocumentName({ accessToken, documentName });
 ```
 
-## Multi-User Client
+### Filters
+
+Query methods, i.e. `queryChunks`, `queryChunksByDocumentName`, support a set of optional filters. The filters are applied in a logical 'AND' operation. If a data source provider does not support a filter-type, then no results from that provider are returned.
+
+```typescript
+import { Filters } from "@redactive/redactive/grpc/search";
+
+// Query chunks from Confluence only, that are from documents created before last week, modified since last week,
+// and that are from documents associated with a user's email. Include chunks from trashed documents.
+const lastWeek = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+const filters: Filters = {
+  scope: ["confluence"],
+  created: {
+    before: lastWeek
+  },
+  modified: {
+    after: lastWeek
+  },
+  userEmails: ["myEmail@example.com"],
+  includeContentInTrash: true
+};
+await client.queryChunks({ accessToken, semanticQuery, filters });
+```
+
+### Multi-User Client
 
 The `MultiUserClient` class helps manage multiple users' authentication and access to the Redactive search service.
 

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -28,6 +28,7 @@ The library has following components.
 
 - **AuthClient** - provides functionality to interact with data sources
 - **SearchClient** - provides functionality to search chunks with Redactive search service in gRPC
+- **MultiUserClient** - provides functionality manage multi-user search with Redactive search service
 
 ### AuthClient
 
@@ -74,6 +75,33 @@ await client.getChunksByUrl({ accessToken, url });
 // Document Name Search : retrieve all chunks of a document identified by its name
 const documentName = "AI Research Paper";
 await client.queryChunksByDocumentName({ accessToken, documentName });
+```
+
+## Multi-User Client
+
+The `MultiUserClient` class helps manage multiple users' authentication and access to the Redactive search service.
+
+```typescript
+import { MultiUserClient } from "@redactive/redactive";
+
+const multiUserClient = MultiUserClient(
+  "REDACTIVE-API-KEY",
+  "https://example.com/callback/",
+  readUserData,
+  multiUserClient
+);
+
+// Present `connection_url` in browser for user to interact with:
+const userId = "myUserId";
+const connectionUrl = await multiUserClient.getBeginConnectionUrl(userId, "confluence");
+
+// On user return from OAuth connection flow:
+let [signInCode, state] = ["", ""]; // from URL query parameters
+const isConnectionSuccessful = await multiUserClient.handleConnectionCallback(userId, signInCode, state);
+
+// User can now use Redactive search service via `MultiUserClient`'s other methods:
+const semanticQuery = "Tell me about the missing research vessel, the Borealis";
+const chunks = await multiUserClient.queryChunks({ userId, semanticQuery });
 ```
 
 ## Development

--- a/sdks/node/src/authClient.ts
+++ b/sdks/node/src/authClient.ts
@@ -22,6 +22,11 @@ export class AuthClient {
   apiKey: string;
   baseUrl: string = "https://api.redactive.ai";
 
+  /**
+   * Initialize the connection settings for the Redactive API.
+   * @param apiKey - The API key used for authentication.
+   * @param baseUrl - The base URL to the Redactive API.
+   */
   constructor(apiKey: string, baseUrl?: string) {
     this.apiKey = apiKey;
     this.baseUrl = baseUrl || this.baseUrl;
@@ -32,6 +37,15 @@ export class AuthClient {
     });
   }
 
+  /**
+   * Return a URL for authorizing Redactive to connect with provider on a user's behalf.
+   * @param provider - The name of the provider to connect with.
+   * @param redirectUri - THE URI to redirect to after initiating the connection. Defaults to an empty string.
+   * @param endpoint - The endpoint to use to access specific provider APIs. Only required if connecting to Zendesk. Defaults to None.
+   * @param codeParamAlias - The alias for the code parameter. This is the name of the query parameter that will need to be passed to the `/auth/token` endpoint as `code`. Defaults to None and will be `code` on the return.
+   * @param state - An optional parameter that is stored as app_callback_state for building callback url. Defaults to None.
+   * @returns The URL to redirect the user to for beginning the connection.
+   */
   async beginConnection({
     provider,
     redirectUri,
@@ -58,6 +72,12 @@ export class AuthClient {
     return response.json().then((data) => data.url);
   }
 
+  /**
+   * Exchange an authorization code and refresh token for access tokens.
+   * @param code - The authorization code received from the OAuth flow. Defaults to None.
+   * @param refreshToken - The refresh token used for token refreshing. Defaults to None.
+   * @returns an object containing access token and other token information.
+   */
   async exchangeTokens(code?: string, refreshToken?: string): Promise<ExchangeTokenResponse> {
     if (!(code || refreshToken)) {
       throw Error("Missing required data");
@@ -76,6 +96,11 @@ export class AuthClient {
     return result as ExchangeTokenResponse;
   }
 
+  /**
+   * Retrieve the list of user's provider connections.
+   * @param accessToken - the user's access token for authentication.
+   * @returns an object container the user ID and current provider connections.
+   */
   async listConnections(accessToken: string): Promise<UserConnections> {
     const response = await fetch(`${this.baseUrl}/api/auth/connections`, {
       method: "GET",

--- a/sdks/node/src/searchClient.ts
+++ b/sdks/node/src/searchClient.ts
@@ -37,6 +37,11 @@ export class SearchClient {
   port: number = 443;
   _cachedServiceClients: Map<string, Client>;
 
+  /**
+   * Redactive API search client.
+   * @param host - The hostname or IP address of the Redactive API service.
+   * @param port - The port number of the Redactive API service.
+   */
   constructor(host?: string, port?: number) {
     this.host = host || this.host;
     this.port = port || this.port;
@@ -55,6 +60,14 @@ export class SearchClient {
     }
   }
 
+  /**
+   * Query for relevant chunks based on a semantic query.
+   * @param accessToken - The user's Redactive access token.
+   * @param semanticQuery - The query string used to find relevant chunks.
+   * @param count - The number of relevant chunks to retrieve. Defaults to 10.
+   * @param filters - An object of filters for querying. Optional.
+   * @returns list of relevant chunks.
+   */
   async queryChunks({
     accessToken,
     semanticQuery,
@@ -87,6 +100,13 @@ export class SearchClient {
     return response.relevantChunks;
   }
 
+  /**
+   * Query for chunks by document name.
+   * @param accessToken - The user's Redactive access token.
+   * @param documentName - The name of the document to retrieve chunks.
+   * @param filters - The filters for querying documents. Optional.
+   * @returns The complete list of chunks for the matching document.
+   */
   async queryChunksByDocumentName({
     accessToken,
     documentName,
@@ -117,6 +137,12 @@ export class SearchClient {
     return response.chunks;
   }
 
+  /**
+   * Get chunks from a document by its URL.
+   * @param accessToken - The user's Redactive access token.
+   * @param url - The URL to the document for retrieving chunks.
+   * @returns The complete list of chunks for the matching document.
+   */
   async getChunksByUrl({ accessToken, url }: GetChunksByUrlSearchParams): Promise<Chunk[]> {
     const requestMetadata = new Metadata();
     requestMetadata.set("Authorization", `Bearer ${accessToken}`);

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -24,10 +24,11 @@ python -m pip install .
 
 ## Usage
 
-The library has following components.
+The library has the following components:
 
 - **AuthClient** - provides functionality to interact with data sources
-- **SearchClient** - provides functionality to search chunks with Redactive search service in gRPC
+- **SearchClient** - provides functionality to search chunks with Redactive search service
+- **MultiUserClient** - provides functionality manage multi-user search with Redactive search service
 - **RerankingSearchClient** [Experimental] - retrieves extra results, then re-ranks them using a more precise ranking function, returning the top_k results
 
 ### AuthClient
@@ -78,11 +79,42 @@ client.get_chunks_by_url(
     url="https://example.com/document"
 )
 
-# Document Name Search : retrieve all chunks of a document identified by its name
+# Document Name Search: retrieve all chunks of a document identified by its name
 client.query_chunks_by_document_name(
     access_token="REDACTIVE-USER-ACCESS-TOKEN",
     document_name="Project Plan"
 )
+```
+
+## Multi-User Client
+
+The `MultiUserClient` class helps manage multiple users' authentication and access to the Redactive search service.
+
+```python
+from redactive.multi_user_client import MultiUserClient
+
+multi_user_client = MultiUserClient(
+    api_key="REDACTIVE-API-KEY",
+    callback_uri="https://example.com/callback/",
+    read_user_data=...,
+    write_user_data=...,
+)
+
+# Present `connection_url` in browser for user to interact with:
+user_id = ...
+connection_url = await multi_user_client.get_begin_connection_url(user_id=user_id, provider="confluence")
+
+# On user return from OAuth connection flow:
+sign_in_code, state = ..., ...  # from URL query parameters
+is_connection_successful = await multi_user_client.handle_connection_callback(
+    user_id=user_id,
+    sign_in_code=sign_in_code,
+    state=state
+)
+
+# User can now use Redactive search service via `MultiUserClient`'s other methods:
+semantic_query = "Tell me about the missing research vessel, the Borealis"
+chunks = await multi_user_client.query_chunks(user_id=user_id, semantic_query=semantic_query)
 ```
 
 ## Development

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -86,7 +86,39 @@ client.query_chunks_by_document_name(
 )
 ```
 
-## Multi-User Client
+### Filters
+
+Query methods, i.e. `query_chunks`, `query_chunks_by_document_name`, support a set of optional filters. The filters are applied in a logical 'AND' operation. If a data source provider does not support a filter-type, then no results from that provider are returned.
+
+```python
+from datetime import datetime, timedelta
+from redactive.search_client import SearchClient
+from redactive.grpc.v1 import Filters
+
+client = SearchClient()
+
+# Query chunks from Confluence only, that are from documents created before last week, modified since last week,
+# and that are from documents associated with a user's email. Include chunks from trashed documents.
+last_week = datetime.now() - timedelta(weeks=1)
+filters = Filters().from_dict({
+  "scope": ["confluence"],
+  "created": {
+    "before": last_week,
+  },
+  "modified": {
+    "after": last_week,
+  },
+  "userEmails": ["myEmail@example.com"],
+  "includeContentInTrash": True,
+})
+client.query_chunks(
+    access_token="REDACTIVE-USER-ACCESS-TOKEN",
+    semantic_query="Tell me about AI",
+    filters=filters
+)
+```
+
+### Multi-User Client
 
 The `MultiUserClient` class helps manage multiple users' authentication and access to the Redactive search service.
 

--- a/sdks/python/src/redactive/auth_client.py
+++ b/sdks/python/src/redactive/auth_client.py
@@ -24,11 +24,11 @@ class BeginConnectionResponse(BaseModel):
 class AuthClient:
     def __init__(self, api_key: str, base_url: str | None = None):
         """
-        Initialize the connection settings for the service.
+        Initialize the connection settings for the Redactive API.
 
         :param api_key: The API key used for authentication.
         :type api_key: str
-        :param base_url: The base URL to use for Redactive.
+        :param base_url: The base URL to the Redactive API.
         :type base_url: str, optional
         """
         if base_url is None:
@@ -45,17 +45,17 @@ class AuthClient:
         state: str | None = None,
     ) -> BeginConnectionResponse:
         """
-        Initiates a connection process with a specified provider.
+        Return a URL for authorizing Redactive to connect with provider on a user's behalf.
 
         :param provider: The name of the provider to connect with.
         :type provider: str
-        :param redirect_uri: The URI to redirect to after initiating the connection. Defaults to an empty string.
+        :param redirect_uri: The URI to redirect to after initiating the connection.
         :type redirect_uri: str
-        :param endpoint: The endpoint to use to access specific provider APIs. Only required if connecting to Zendesk. Defaults to None.
+        :param endpoint: The endpoint to use to access specific provider APIs. Only required if connecting to Zendesk.
         :type endpoint: str, optional
         :param code_param_alias: The alias for the code parameter. This is the name of the query parameter that will need to be passed to the `/auth/token` endpoint as `code`. Defaults to None and will be `code` on the return.
         :type code_param_alias: str, optional
-        :param state: An optional parameter that is stored as app_callback_state for building callback url. Defaults to None.
+        :param state: An optional parameter that is stored as app_callback_state for building callback url.
         :type state: str, optional
         :raises httpx.RequestError: If an error occurs while making the HTTP request.
         :return: The URL to redirect the user to for beginning the connection.
@@ -78,15 +78,14 @@ class AuthClient:
         """
         Exchange an authorization code and refresh token for access tokens.
 
-        :param code: The authorization code received from the OAuth flow, defaults to None
-        :type code: str | None, optional
-        :param refresh_token: The refresh token used for token refreshing, defaults to None
-        :type refresh_token: str | None, optional
+        :param code: The authorization code received from the OAuth flow.
+        :type code: str, optional
+        :param refresh_token: The refresh token used for token refreshing.
+        :type refresh_token: str, optional
         :raises httpx.RequestError: If an error occurs while making the HTTP request.
         :return: An object containing access token and other token information.
         :rtype: ExchangeTokenResponse
         """
-
         body = {}
         if code:
             body["code"] = code
@@ -101,9 +100,9 @@ class AuthClient:
 
     async def list_connections(self, access_token: str) -> ListConnectionsResponse:
         """
-        Retrieve the list of user connections.
+        Retrieve the list of user's provider connections.
 
-        :param access_token: The access token for authentication.
+        :param access_token: The user's access token for authentication..
         :type access_token: str
         :raises httpx.RequestError: If an error occurs while making the HTTP request.
         :return: An object containing the user ID and current connections.

--- a/sdks/python/src/redactive/reranking/reranker.py
+++ b/sdks/python/src/redactive/reranking/reranker.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
+from typing import Any
 
 from rerankers import Reranker
 
 from redactive import search_client
-from redactive.grpc.v1 import RelevantChunk
+from redactive.grpc.v1 import Filters, RelevantChunk
 
 
 @dataclass
@@ -33,8 +34,8 @@ class RerankingSearchClient(search_client.SearchClient):
         access_token: str,
         semantic_query: str,
         count: int = 3,
-        query_filter: dict | None = None,
-        filters: dict | None = None,
+        query_filter: dict[str, Any] | None = None,
+        filters: Filters | dict[str, Any] | None = None,
     ) -> list[RelevantChunk]:
         # Get many more results than the user is asking for, then
         # rerank them

--- a/sdks/python/tests/unit_tests/multi_user_client_tests.py
+++ b/sdks/python/tests/unit_tests/multi_user_client_tests.py
@@ -96,10 +96,12 @@ async def test_query_chunks(multi_user_client: MultiUserClient, mock_search_clie
     multi_user_client.search_client.query_chunks.return_value = relevant_chunks
     multi_user_client.read_user_data.side_effect = mock_read_user_data
 
-    result = await multi_user_client.query_chunks(user_id, semantic_query, count, filters)
+    result = await multi_user_client.query_chunks(user_id, semantic_query, count, filters=filters)
 
     assert result == relevant_chunks
-    multi_user_client.search_client.query_chunks.assert_called_with("idToken123", semantic_query, count, filters)
+    multi_user_client.search_client.query_chunks.assert_called_with(
+        "idToken123", semantic_query, count, filters=filters
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Node SDK
- Add missing docstrings 
- Add multi-user client to readme

## Python SDK
- Update docstrings
- Add type hint & support for `Filters` in query-chunks
- Change query-chunks count default to 10; in line with best performance practices & the Node SDK.
- Add multi-user client to readme
